### PR TITLE
fix: type route query refs as string in remesas

### DIFF
--- a/app/pages/remesas.vue
+++ b/app/pages/remesas.vue
@@ -508,11 +508,11 @@ const rows = computed<RemesaRow[]>(() => {
 })
 
 const searchQuery = useRouteQuery('q', '')
-const monedaFilter = useRouteQuery('moneda', 'all')
-const cuentaPropiaFilter = useRouteQuery('propia', 'all')
-const inversionesFilter = useRouteQuery('inv', 'all')
-const tarjetaFilter = useRouteQuery('tarjeta', 'all')
-const sortQuery = useRouteQuery('sort', '[{"id":"retiroArsSort","desc":false}]')
+const monedaFilter = useRouteQuery<string>('moneda', 'all')
+const cuentaPropiaFilter = useRouteQuery<string>('propia', 'all')
+const inversionesFilter = useRouteQuery<string>('inv', 'all')
+const tarjetaFilter = useRouteQuery<string>('tarjeta', 'all')
+const sortQuery = useRouteQuery<string>('sort', '[{"id":"retiroArsSort","desc":false}]')
 
 type SortingState = Array<{ id: string; desc: boolean }>
 


### PR DESCRIPTION
## Problema

`app/pages/remesas.vue` tenía **5 errores de tipos latentes** (nunca detectados porque el CI solo corre lint, no typecheck):

- `sortQuery` — `Type 'string' is not assignable to type '"[{\"id\":\"retiroArsSort\",\"desc\":false}]"'` en la asignación `sortQuery.value = serialized` (línea 542)
- `monedaFilter`, `cuentaPropiaFilter`, `inversionesFilter`, `tarjetaFilter` — `Type 'string' is not assignable to type '"all"'` en las asignaciones `@click="...Filter = option"` del template (líneas 894, 912, 930, 948)

**Causa raíz:** `useRouteQuery` infiere el **tipo literal** del default (el string JSON o `'all'`) en lugar de `string`, por lo que cualquier asignación de un `string` general falla en el typechecker. Es el mismo error que tenía `app/pages/fondos/index.vue` y que se resolvió en el PR #326.

> Nota: en este archivo el error era **solo de compilación** — la URL nunca se corrompió en runtime (el patrón string-JSON ya era correcto).

## Solución

Se anota explícitamente el genérico `<string>` en las 5 declaraciones de `useRouteQuery` — el mismo patrón ya usado en `app/pages/fondos/index.vue`:

```ts
const monedaFilter = useRouteQuery<string>('moneda', 'all')
const cuentaPropiaFilter = useRouteQuery<string>('propia', 'all')
const inversionesFilter = useRouteQuery<string>('inv', 'all')
const tarjetaFilter = useRouteQuery<string>('tarjeta', 'all')
const sortQuery = useRouteQuery<string>('sort', '[{"id":"retiroArsSort","desc":false}]')
```

## Verificación

- [x] `nuxi typecheck`: los 5 errores `TS2322` desaparecen (quedan solo 3 errores preexistentes ajenos a este cambio: módulo `@vueuse/core`, overload en línea 443 y `children` en `useHead`)
- [x] `pnpm lint`: sin errores reales en el archivo (el ruido CRLF local no aplica en CI)
- [x] Probado en dev server: filtros y ordenamiento funcionan correctamente, URL de sort intacta

## Notas

- Es un cambio **solo de tipos** — no altera el comportamiento en runtime de la página
- `searchQuery` (`useRouteQuery('q', '')`) no requería fix: TypeScript widen automáticamente el string vacío en inferencia

---

Hecho por DeepSeek V4 flash (0731)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Se han precisado internamente las declaraciones de los filtros de moneda, cuenta propia, inversiones y tarjeta, así como del criterio de ordenamiento.
  * No se han modificado las claves, los valores predeterminados ni la lógica existente.

* **Impacto para usuarios**
  * No hay cambios visibles en el funcionamiento de los filtros ni en la conservación de los parámetros de consulta.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->